### PR TITLE
Cancel line breaks

### DIFF
--- a/src/editor_extension/BlockTagging.js
+++ b/src/editor_extension/BlockTagging.js
@@ -1,10 +1,11 @@
 import {Extension} from 'rich-markdown-editor';
+import CancelLineBreaksPlugin from './plugins/CancelLineBreaks';
 import SelectNodePlugin from './plugins/SelectNode';
 import TagFilteringPlugin from './plugins/TagFiltering';
 
 class BlockTagging extends Extension {
   get name() { return 'yada-blockTagging'; }
-  get plugins() { return [SelectNodePlugin, TagFilteringPlugin]; }
+  get plugins() { return [CancelLineBreaksPlugin, SelectNodePlugin, TagFilteringPlugin]; }
 }
 
 export default new BlockTagging();

--- a/src/editor_extension/plugins/CancelLineBreaks.js
+++ b/src/editor_extension/plugins/CancelLineBreaks.js
@@ -1,0 +1,27 @@
+import {Plugin, PluginKey} from 'prosemirror-state';
+import {checkSourceFileId} from '../../util/FileIdAndTypeUtils';
+import {TagFilteringPluginKey} from './TagFiltering';
+import store from '../../store';
+
+const CANCEL_LINE_BREAKS_PLUGIN_NAME = 'cancel-line-breaks';
+export const CancelLineBreaksPluginKey = new PluginKey(CANCEL_LINE_BREAKS_PLUGIN_NAME);
+
+const checkInsertLineBreakReplaceStep = step => step.slice.content.content.some(node => !node.isLeaf);
+
+const checkRemoveLineBreakReplaceStep = (step, doc) => {
+  if (step.from === step.to) { return false; }
+  const fromNode = doc.nodeAt(step.from);
+  const toNode = doc.nodeAt(step.to);
+  if (toNode) { return !fromNode || (fromNode && !fromNode.eq(toNode)); }
+  return !fromNode || !doc.nodeAt(step.to - 1).eq(fromNode);
+};
+
+export default new Plugin({
+  key: CancelLineBreaksPluginKey,
+  filterTransaction: (tr, state) =>
+    (checkSourceFileId(store.getState().currentOpenFileId) && !TagFilteringPluginKey.getState(state)) ||
+    tr.steps.every(
+      step => step.toJSON().stepType !== 'replace' ||
+        (!checkInsertLineBreakReplaceStep(step) && !checkRemoveLineBreakReplaceStep(step, state.doc))
+    ),
+});

--- a/src/editor_extension/plugins/SelectNode.js
+++ b/src/editor_extension/plugins/SelectNode.js
@@ -1,14 +1,10 @@
 import {Plugin, PluginKey} from 'prosemirror-state';
 import {Decoration, DecorationSet} from 'prosemirror-view';
-import store from '../../store';
-import {FILE_TYPE, getFileType} from '../../util/FileIdAndTypeUtils';
 import {setSelectNodeAction} from '../../reducers/CurrentOpenFileState';
-import {TagFilteringPluginKey} from './TagFiltering';
+import store from '../../store';
 
 const SELECT_NODE_PLUGIN_NAME = 'select-node';
 export const SelectNodePluginKey = new PluginKey(SELECT_NODE_PLUGIN_NAME);
-
-const checkEnterStepType = step => step.stepType === 'replace' && step.from === step.to && step.structure;
 
 export default new Plugin({
   key: SelectNodePluginKey,
@@ -26,11 +22,6 @@ export default new Plugin({
       ) { store.dispatch(setSelectNodeAction(newState ? { pos: newState.pos } : null)); }
       return newState;
     },
-  },
-  filterTransaction: (tr, state) => {
-    const currentOpenFileId = store.getState().currentOpenFileId;
-    return (getFileType(currentOpenFileId) === FILE_TYPE.SOURCE && !TagFilteringPluginKey.getState(state)) ||
-      tr.steps.every(step => !checkEnterStepType(step.toJSON()));
   },
   props: {
     decorations: state => {

--- a/src/util/FileIdAndTypeUtils.js
+++ b/src/util/FileIdAndTypeUtils.js
@@ -9,5 +9,9 @@ export const validateHasFileIdObj = state => state.hasOwnProperty('fileId') && v
 export const getFileType = fileId => validateFileIdObj(fileId) && fileId.sourceId
   ? (fileId.viewId ? FILE_TYPE.VIEW : FILE_TYPE.SOURCE) : null;
 
+export const checkNoOpenFileId = fileId => validateFileIdObj(fileId) && !fileId.sourceId && !fileId.viewId;
+export const checkSourceFileId = fileId => validateFileIdObj(fileId) && fileId.sourceId && !fileId.viewId;
+export const checkViewFileId = fileId => validateFileIdObj(fileId) && fileId.sourceId && fileId.viewId;
+
 export const getFileIdKeyStr = fileId => validateFileIdObj(fileId)
   ? (fileId.sourceId + (fileId.viewId ? '#' + fileId.viewId : '')) : '';


### PR DESCRIPTION
When a view is shown an editor, or when filters are applied, we don't want to be able to add or remove line breaks (for filtering that ends up with unintended changes to the source, for views, we can just set to readonly for now, but in case we want to be able to edit individual blocks, this allows the block level to be readonly).