### PR TITLE
landing page auth login, etc

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,7 @@
 .App {
   height: 100vh;
   min-width: 680px;
+  min-height: 240px;
   box-sizing: border-box;
   display: flex;
 }
@@ -27,7 +28,7 @@
   flex: none;
   width: 224px;
   padding: 9px 0;
-  border-right: 3px solid darkgray;
+  border-right: 3px solid gray;
   display: flex;
   flex-direction: column;
 }
@@ -61,7 +62,7 @@
   min-width: 0;
 }
 
-.InputRow>input, .InputRow>button, .ButtonRow input, .ButtonRow button {
+.InputRow>input, .InputRow>button, .ButtonRow>input, .ButtonRow>button {
   margin-left: 1px;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,19 @@
 import './App.css';
 import React from 'react';
 import {connect} from 'react-redux';
-import {BACKEND_MODE_SIGNED_IN_STATUS} from './reducers/BackendModeSignedInStatus';
+import {
+  BACKEND_MODE_SIGNED_IN_STATUS,
+  getUserSignedInStatus,
+  setBackendModeSignedInStatusAction,
+} from './reducers/BackendModeSignedInStatus';
 import LandingPage from './components/LandingPage';
 import Navigator from './components/Navigator';
 import Editor, {handleSaveCurrentFileEditorContent} from './components/Editor';
 
 class App extends React.Component {
-	
+
+  state = { mounted: false };
+
   keydownHandler = event => {
     if ((window.navigator.platform.match("Mac") ? event.metaKey : event.ctrlKey) && event.keyCode === 83) {
       event.preventDefault();
@@ -16,28 +22,47 @@ class App extends React.Component {
       }
     }
   }
-	
-	componentDidMount = () => { document.addEventListener('keydown',this.keydownHandler); };
-	componentWillUnmount = () => { document.removeEventListener('keydown', this.keydownHandler); };
+
+  componentWillUnmount = () => { document.removeEventListener('keydown', this.keydownHandler); };
+
+  componentDidMount = () => {
+    document.addEventListener('keydown',this.keydownHandler);
+    if (this.props.backendModeSignedInStatus !== BACKEND_MODE_SIGNED_IN_STATUS.LOCAL_STORAGE) {
+      getUserSignedInStatus().then(backendModeSignedInStatus => {
+        this.props.dispatchSetBackendModeSignedInStatusAction(backendModeSignedInStatus);
+        this.setState({ mounted: true });
+      });
+    } else { this.setState({ mounted: true }); }
+  };
   
-  render = () => this.props.backendModeSignedInStatus !== BACKEND_MODE_SIGNED_IN_STATUS.USER_SIGNED_OUT
-    ? (
-        // <React.Fragment>
-        <div className="App">
-          <div style={{ position: 'fixed', top: '9px', right: '16px', fontSize: '.75em' }}>
-            <span role="img" aria-label="Yet Another Docs App">
-              🐇 &nbsp; <b>Y</b>et <b>A</b>nother <b>D</b>ocs <b>A</b>pp
-            </span>
-          </div>
-          <Navigator />
-          <Editor />
-        </div>
-          // <div className="NoApp">
-          //   This app doesn't support mobile screen widths.
-          // </div>
-        // </React.Fragment>
-      )
-    : (<LandingPage />);
+  render = () =>
+    <React.Fragment>
+      {
+        this.state.mounted
+          ? (
+              this.props.backendModeSignedInStatus !== BACKEND_MODE_SIGNED_IN_STATUS.USER_SIGNED_OUT
+                ? <div className="App">
+                    <div style={{ position: 'absolute', top: '9px', right: '16px', fontSize: '.75em' }}>
+                      <span role="img" aria-label="Yet Another Docs App">
+                        🐇 &nbsp; <b>Y</b>et <b>A</b>nother <b>D</b>ocs <b>A</b>pp
+                      </span>
+                    </div>
+                    <Navigator />
+                    <Editor />
+                  </div>
+                : <LandingPage />
+            )
+          : null
+      }
+      {/* <div className="NoApp">
+        This app doesn't support mobile screen widths.
+      </div> */}
+    </React.Fragment>
 };
 
-export default connect(state => ({ backendModeSignedInStatus: state.backendModeSignedInStatus }))(App);
+export default connect(
+  state => ({ backendModeSignedInStatus: state.backendModeSignedInStatus }),
+  dispatch => ({
+    dispatchSetBackendModeSignedInStatusAction: mode => dispatch(setBackendModeSignedInStatusAction(mode)),
+  }),
+)(App);

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -536,10 +536,11 @@ class Navigator extends React.Component {
           }
           <button
             onClick={() => {
-              this.handleSwitchBackendModeSignedInStatus(
-                this.props.backendModeSignedInStatus === BACKEND_MODE_SIGNED_IN_STATUS.LOCAL_STORAGE
-                  ? getUserSignedInStatus() : BACKEND_MODE_SIGNED_IN_STATUS.LOCAL_STORAGE
-              );
+              if (this.props.backendModeSignedInStatus === BACKEND_MODE_SIGNED_IN_STATUS.LOCAL_STORAGE) {
+                getUserSignedInStatus().then(backendModeSignedInStatus => {
+                  this.handleSwitchBackendModeSignedInStatus(backendModeSignedInStatus);
+                });
+              } else { this.handleSwitchBackendModeSignedInStatus(BACKEND_MODE_SIGNED_IN_STATUS.LOCAL_STORAGE); }
             }}>
             {
               'Switch to ' +

--- a/src/reducers/BackendModeSignedInStatus.js
+++ b/src/reducers/BackendModeSignedInStatus.js
@@ -1,6 +1,5 @@
-import axios from 'axios';
 import Cookies from 'js-cookie';
-// import {fetchWithTimeout} from '../util/FetchWithTimeout';
+import {fetchWithTimeout} from '../util/FetchWithTimeout';
 
 export const SERVER_BASE_URL = process.env.NODE_ENV === 'development'
   ? "http://localhost:5000/" : "https://yaas.azurewebsites.net/";
@@ -13,43 +12,28 @@ export const BACKEND_MODE_SIGNED_IN_STATUS = {
 
 export const ACCESS_TOKEN_COOKIE_KEY = 'access_token';
 
-export async function loginBackend(name, email, token) {
-  await axios.post(
-    SERVER_BASE_URL + "register_user",
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Set-Cookie': `token=${token}` },
-      body: JSON.stringify({ name, email, token })
-    },
-    { withCredentials: true },
-  );
-  return true;
-};
-
-export const INITIAL_LOCAL_STORAGE_BACKEND_MODE_LOCAL_STORAGE_KEY = 'initialLocalStorageBackendMode';
-
-export const getUserSignedInStatus = () => {
+export const getUserSignedInStatus = async () => {
   const token = Cookies.get(ACCESS_TOKEN_COOKIE_KEY);
   if (token) {
-    return BACKEND_MODE_SIGNED_IN_STATUS.USER_SIGNED_IN;
-    // TODO
-    // try {
-    //   const { ok } = fetchWithTimeout(
-    //     SERVER_BASE_URL + `auth`,
-    //     { headers: new Headers({ 'Set-Cookie': `token=${token}` }) },
-    //   );
-    //   if (ok) { return BACKEND_MODE_SIGNED_IN_STATUS.USER_SIGNED_IN; }
-    // } catch (e) { console.log(e); }
+    try {
+      const { ok } = await fetchWithTimeout(
+        SERVER_BASE_URL + `auth`,
+        { headers: new Headers({ 'Set-Cookie': `token=${token}` }) },
+      );
+      if (ok) { return BACKEND_MODE_SIGNED_IN_STATUS.USER_SIGNED_IN; }
+    } catch (e) { console.log(e); }
   }
   return BACKEND_MODE_SIGNED_IN_STATUS.USER_SIGNED_OUT;
 };
+
+export const INITIAL_LOCAL_STORAGE_BACKEND_MODE_LOCAL_STORAGE_KEY = 'initialLocalStorageBackendMode';
 
 const SET_BACKEND_MODE_SIGNED_IN_STATUS_ACTION_TYPE = 'backendModeSignedInStatus/set';
 export const setBackendModeSignedInStatusAction =
   status => ({ type: SET_BACKEND_MODE_SIGNED_IN_STATUS_ACTION_TYPE, status });
 export const backendModeSignedInStatusReducer = (
-  state = !localStorage.getItem(INITIAL_LOCAL_STORAGE_BACKEND_MODE_LOCAL_STORAGE_KEY)
-    ? getUserSignedInStatus() : BACKEND_MODE_SIGNED_IN_STATUS.LOCAL_STORAGE,
+  state = localStorage.getItem(INITIAL_LOCAL_STORAGE_BACKEND_MODE_LOCAL_STORAGE_KEY)
+    ? BACKEND_MODE_SIGNED_IN_STATUS.LOCAL_STORAGE : BACKEND_MODE_SIGNED_IN_STATUS.USER_SIGNED_OUT,
   action,
 ) => {
   if (

--- a/src/util/FetchWithTimeout.js
+++ b/src/util/FetchWithTimeout.js
@@ -1,4 +1,4 @@
-export async function fetchWithTimeout(uri, options, time = 5000) {
+export const fetchWithTimeout = async (uri, options, time = 7500) => {
   const controller = new AbortController();
   setTimeout(() => { controller.abort(); }, time);
   return await fetch(uri, { ...options, signal: controller.signal }).then((response) => {


### PR DESCRIPTION
The main functional change here is to use the auth endpoint to authenticate the locally stored user access token before logging in/setting the backend mode to logged in.