### PR TITLE
Toast + View Save + View Editor Aesthetics

### DIFF
--- a/src/backend/HostedFileStorageSystemClient.js
+++ b/src/backend/HostedFileStorageSystemClient.js
@@ -19,21 +19,19 @@ export default {
   },
   doSaveViewSpec: async (tagsList, sourceId, viewId, type, createNew) => {
     const token = Cookies.get(ACCESS_TOKEN_COOKIE_KEY);
-    try {
-      const response = await fetchWithTimeout(
+    const response = await fetchWithTimeout(
         SERVER_BASE_URL + `view?docID=${sourceId}&viewType=${type}` + (!createNew ? `&viewID=${viewId}` : ''),
         {
           method: 'PUT',
           body: JSON.stringify({ tags: tagsList }),
           headers: new Headers({ 'Content-Type': 'application/json', 'Set-Cookie': `token=${token}` }),
         },
-      );
-      if (response.ok) {
-        const { viewID } = await response.json();
-        return { id: viewID, sourceId: sourceId, ...(createNew ? { name:"Untitled", type } : null) };
-      };
-    } catch (e) { console.log(e); }
-    return null;
+    );
+    if (response.ok) {
+      const { viewID } = await response.json();
+      return { id: viewID, sourceId: sourceId, ...(createNew ? { name:"Untitled", type } : null) };
+    }
+    throw new Error("Failed to save view");
   },
   doGetView: async (fileId) => {
     const token = Cookies.get(ACCESS_TOKEN_COOKIE_KEY);

--- a/src/components/CardView/Card.js
+++ b/src/components/CardView/Card.js
@@ -6,7 +6,6 @@ import ReactCardFlip from 'react-card-flip';
 class Card extends React.Component {
 	constructor(props) {
 		super(props);
-		console.log(this.props.content);
 		this.state = {
 			isFlipped: false,
 			key: this.props.content["index"],

--- a/src/components/CardView/CardDeck.js
+++ b/src/components/CardView/CardDeck.js
@@ -10,6 +10,9 @@ import TagEditor from '../ViewComponents/TagEditor';
 import {setTagsInViewAction} from '../../reducers/SetTagsInView';
 import FileStorageSystemClient from "../../backend/FileStorageSystemClient";
 import {FILE_TYPE} from "../../util/FileIdAndTypeUtils";
+import {setToastAction, TOAST_SEVERITY} from "../../reducers/Toast";
+import store from "../../store";
+import {CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE} from "../../reducers/CurrentOpenFileState";
 
 
 class CardDeck extends React.Component {
@@ -32,8 +35,19 @@ class CardDeck extends React.Component {
 				FILE_TYPE.CARD_VIEW,
 				false,
 			)
-				.then(() => alert("Card view saved"))
-				.catch(() => alert("Failed to save card view"));
+				.then(() => {
+					this.props.dispatchSetToastAction({
+						message: "Saved view",
+						severity: TOAST_SEVERITY.SUCCESS,
+						open: true
+					});
+					store.dispatch({ type: CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE });
+				})
+				.catch(() => this.props.dispatchSetToastAction({
+					message: "Failed to save view",
+					severity: TOAST_SEVERITY.ERROR,
+					open: true
+				}));
 		}
 	};
 	
@@ -87,7 +101,7 @@ class CardDeck extends React.Component {
 			}
 			return (
 				<Container className="viewContainer">
-					<TagEditor allTagsData={this.state.allTagsData} tagsInView={this.props.tagsInView} />
+					<TagEditor viewType={FILE_TYPE.CARD_VIEW} allTagsData={this.state.allTagsData} tagsInView={this.props.tagsInView} />
 					{cards}
 				</Container>
 			);
@@ -97,5 +111,8 @@ class CardDeck extends React.Component {
 
 export default connect(
 	state => ({ tagsInView: state.tagsInView, currentOpenFileId: state.currentOpenFileId }),
-	dispatch => ({ setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)) }),
+	dispatch => ({
+		setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)),
+		dispatchSetToastAction: toast => dispatch(setToastAction(toast)),
+	}),
 )(CardDeck);

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,31 +1,14 @@
 import './Editor.css';
 import React from 'react';
 import {connect} from 'react-redux';
-import {checkNoOpenFileId, checkSourceFileId} from '../util/FileIdAndTypeUtils';
+import {checkNoOpenFileId} from '../util/FileIdAndTypeUtils';
 import {
-  CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE,
   SET_SAVE_DIRTY_FLAG_ACTION_TYPE,
 } from '../reducers/CurrentOpenFileState';
 import {TextSelection} from 'prosemirror-state';
 import TagMenu from './TagMenu';
 import RichMarkdownEditor from 'rich-markdown-editor';
-
-import store from '../store';
-import FileStorageSystemClient from '../backend/FileStorageSystemClient';
 import BlockTaggingEditorExtension from '../editor_extension/BlockTagging';
-
-export const handleSaveCurrentFileEditorContent = () => {
-  const currentOpenFileId = store.getState().currentOpenFileId;
-  if (checkSourceFileId(store.getState().currentOpenFileId) && store.getState().saveDirtyFlag) {
-    FileStorageSystemClient.doSaveSourceContent(
-      BlockTaggingEditorExtension.editor.value(true),
-      currentOpenFileId.sourceId,
-    ).then(success => {
-      if (success) { store.dispatch({ type: CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE }); }
-      else { alert('failed to save source content'); }
-    });
-  }
-};
 
 class Editor extends React.Component {
   render = () => {

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -9,13 +9,18 @@ import DescriptionIcon from '@material-ui/icons/Description';
 import Link from '@material-ui/core/Link';
 import TextFieldsIcon from '@material-ui/icons/TextFields';
 import AmpStoriesIcon from '@material-ui/icons/AmpStories';
-import {FILE_TYPE, checkNoOpenFileId, checkSourceFileId} from '../util/FileIdAndTypeUtils';
+import {
+	FILE_TYPE,
+	checkNoOpenFileId,
+	checkSourceFileId,
+	checkViewFileId,
+	NO_OPEN_FILE_ID
+} from '../util/FileIdAndTypeUtils';
 import Button from '@material-ui/core/Button';
 import SaveIcon from '@material-ui/icons/Save';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import IconButton from '@material-ui/core/IconButton';
 import SearchIcon from '@material-ui/icons/Search';
-import {handleSaveCurrentFileEditorContent} from './Editor';
 import {parse as parseTagFilters} from '../lib/TagFiltersGrammar';
 import BlockTaggingEditorExtension from '../editor_extension/BlockTagging';
 import {TagFilteringPluginKey} from '../editor_extension/plugins/TagFiltering';
@@ -26,266 +31,341 @@ import RemoveCircleIcon from '@material-ui/icons/RemoveCircle';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
+import {setToastAction, TOAST_SEVERITY} from "../reducers/Toast";
+import store from "../store";
+import {CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE} from "../reducers/CurrentOpenFileState";
 
 const TAG_FILTERS_INPUT_ID = 'tag_filters_input';
 
 const DEFAULT_STATE = {
-  modifyingTagFilters: false,
-  currentTagFiltersStr: '',
-  currentParsedTagFiltersStr: '',
-  sourceSavedTagFilters: {},
+	modifyingTagFilters: false,
+	currentTagFiltersStr: '',
+	currentParsedTagFiltersStr: '',
+	sourceSavedTagFilters: {},
 };
 
 class Navbar extends React.Component {
-  state = DEFAULT_STATE;
-
-  handleCancelModifyingTagFilters = () => {
-    const input = document.getElementById(TAG_FILTERS_INPUT_ID);
-    input.value = this.state.currentTagFiltersStr;
-    this.setState({ modifyingTagFilters: false });
-  };
-
-  handleStartModifyingTagFilters = () => {
-    this.setState({ modifyingTagFilters: true });
-    defer(() => {
-      const input = document.getElementById(TAG_FILTERS_INPUT_ID);
-      input.focus();
-      input.setSelectionRange(input.value.length, input.value.length);
-    });
-  };
-
-  handleUnpersistCurrentTagFilters = () => {
-    if (
-      !this.state.currentTagFiltersStr ||
-      !this.state.sourceSavedTagFilters.hasOwnProperty(this.state.currentTagFiltersStr)
-    ) { return false; }
-    const newSourceSavedTagFilters = {...this.state.sourceSavedTagFilters};
-    delete newSourceSavedTagFilters[this.state.currentTagFiltersStr];
-    FileStorageSystemClient.doSetSourceSavedTagFilters(
-      this.props.currentOpenFileId.sourceId,
-      newSourceSavedTagFilters,
-    ).then(success => {
-      if (!success) { alert('failed to set source saved tag filters'); }
-      else { this.setState({ sourceSavedTagFilters: newSourceSavedTagFilters }); }
-    });
-  };
-
-  handlePersistNewSavedTagFilters = () => {
-    if (
-      !this.state.currentTagFiltersStr ||
-      this.state.sourceSavedTagFilters.hasOwnProperty(this.state.currentTagFiltersStr)
-    ) { return false; }
-    const newSourceSavedTagFilters = {...this.state.sourceSavedTagFilters};
-    newSourceSavedTagFilters[this.state.currentTagFiltersStr] = this.state.currentParsedTagFiltersStr;
-    FileStorageSystemClient.doSetSourceSavedTagFilters(
-      this.props.currentOpenFileId.sourceId,
-      newSourceSavedTagFilters,
-    ).then(success => {
-      if (!success) { alert('failed to set source saved tag filters'); }
-      else { this.setState({ sourceSavedTagFilters: newSourceSavedTagFilters }); }
-    });
-  };
-
-  handleApplyTagFilters = () => {
-    let tagFilters = null;
-    const tagFiltersStr = document.getElementById(TAG_FILTERS_INPUT_ID).value.trim();
-    if (tagFiltersStr) {
-      tagFilters = parseTagFilters(tagFiltersStr);
-      if (!tagFilters) {
-        alert('invalid tag filters');
-        return false;
-      }
-    }
-    document.getElementById(TAG_FILTERS_INPUT_ID).value = tagFiltersStr;
-    const parsedTagFiltersStr = JSON.stringify(tagFilters);
-    const oldParsedTagFiltersStr = this.state.currentParsedTagFiltersStr;
-    this.setState({ currentTagFiltersStr: tagFiltersStr, currentParsedTagFiltersStr: parsedTagFiltersStr });
-    if (parsedTagFiltersStr === oldParsedTagFiltersStr) { return true; }
-    if(BlockTaggingEditorExtension.editor !== undefined){
-      BlockTaggingEditorExtension.editor.view.dispatch(
-        BlockTaggingEditorExtension.editor.view.state.tr.setMeta(TagFilteringPluginKey, tagFilters)
-          .setSelection(
-            tagFilters
-              ? TextSelection.create(BlockTaggingEditorExtension.editor.view.state.doc, 0, 0)
-              : Selection.atStart(BlockTaggingEditorExtension.editor.view.state.doc)
-          ).scrollIntoView()
-      );
-      defer(() => {
-        if (tagFilters) { BlockTaggingEditorExtension.editor.view.dom.blur(); }
-        else { BlockTaggingEditorExtension.editor.view.focus(); }
-      });
-    }
-    return true;
-  };
-
-  changeFile = async () => {
-    if (checkSourceFileId(this.props.currentOpenFileId)) {
-        FileStorageSystemClient.doGetSourceSavedTagFilters(this.props.currentOpenFileId.sourceId)
-            .then(sourceSavedTagFilters => {
-              if (!sourceSavedTagFilters) {
-                //alert('failed to retrieve source saved tag filters');
-              } else {
-                let filters = {}
-                sourceSavedTagFilters.forEach(element => {
-                  filters[element] = element;
-                });
-                this.setState({sourceSavedTagFilters: filters});
-              }
-            });
-    }
-  };
-
-  componentDidMount = () => {
-    this.changeFile();
-  };
-
-  componentDidUpdate = prevProps => {
-    console.log(this.props.currentOpenFileId);
-    if(this.props.currentOpenFileName.viewName === '' && prevProps.currentOpenFileId.sourceId !== this.props.currentOpenFileId.sourceId){
-        document.getElementById(TAG_FILTERS_INPUT_ID).value = "";
-        this.handleApplyTagFilters();
-        this.setState({ sourceSavedTagFilters: {} });
-        this.changeFile();
-      }
-  };
-
-  render = () => {
-    const noOpenFileIdCheck = checkNoOpenFileId(this.props.currentOpenFileId);
-    const currentTagFiltersSaved =this.state.sourceSavedTagFilters.hasOwnProperty(this.state.currentTagFiltersStr);
-    return(
-            <AppBar position="static" class="custom-navbar">
-                <Toolbar>
-                    <img className={"menuButton"} src={require('../images/logo.png')} style={{width: "40px", marginRight: "10px"}} alt={"MENU"}/>
-                    <Typography variant="h5" style={{fontFamily:"Bungee", color:"#F5F0E1"}}>
-                        YADA
-                    </Typography>
-                    <div style={{flexGrow: 1, marginLeft: "150px"}}>
-                        {this.props.currentOpenFileName.sourceName === '' ? null :
-                        <Breadcrumbs aria-label="breadcrumb" color="secondary" style={{marginRight: "10px", float: "left", border:"1px solid #F5F0E1", borderRadius: "10px", padding: "8px"}}>
-                            <Link color="inherit" style={{ color: "#F5F0E1",}}> 
-                            <DescriptionIcon color="secondary"/>
-                                {this.props.currentOpenFileName.sourceName}
-                            </Link>
-                            {this.props.currentOpenFileName.viewName === '' ? null :
-                                <Link color="inherit" style={{color: "#F5F0E1"}}> 
-                                {
-                                    (this.props.currentOpenFileId.viewType === FILE_TYPE.CARD_VIEW) ? 
-                                        <AmpStoriesIcon color="secondary"/>:
-                                    (this.props.currentOpenFileId.viewType === FILE_TYPE.TEXT_VIEW) ?
-                                        <TextFieldsIcon color="secondary"/> :
-                                    null
-                                }
-                                {this.props.currentOpenFileName.viewName}
-                                </Link>
-                            }
-                        </Breadcrumbs>
-                        }
-                        <Button
-                        variant="outlined"
-                        color="secondary"
-                        title="save"
-                        disabled={noOpenFileIdCheck || !this.props.saveDirtyFlag}
-                        onClick={handleSaveCurrentFileEditorContent}
-                        startIcon={<SaveIcon />}
-                        style= {{ borderRadius: "10px",paddingTop: "8px", paddingBottom: "8px", float: "left", marginRight: "20px" }}
-                        >
-                            Save
-                        </Button>
-                        {
-                            this.props.currentOpenFileName.viewName === '' ?
-                            <div style={{backgroundColor: "rgba(245, 240, 225, 0.8)", marginLeft: "250px", width: "50vw", borderRadius: "10px", padding: "5px"}}>
-                                <Grid container>
-                                  <Grid item xs={1}>
-                                    <div style={{marginTop: "3px", marginLeft: "20px"}}>
-                                        <SearchIcon color="primary"/>
-                                    </div>
-                                  </Grid>
-                                  <Grid item xs={10}>
-                                  <Autocomplete
-                                    value={this.state.currentTagFiltersStr}
-                                    id={TAG_FILTERS_INPUT_ID}
-                                    freeSolo
-                                    options={Object.entries(this.state.sourceSavedTagFilters)
-                                      .map(([tagFiltersStr, _parsedTagFiltersStr]) => tagFiltersStr)}
-                                    renderInput={(params) => (
-                                      <TextField 
-                                            {...params} 
-                                            placeholder="Search with Tags: ( #{tag1} | !( #{tag2} ) ) & #{tag3}"
-                                            style={{margin:"0%"}}
-                                            margin="normal" 
-                                            variant="standard"
-                                            />
-                                    )}
-                                    onChange={(event, value, reason) => {
-                                      this.setState({currentTagFiltersStr : value});
-                                      this.handleStartModifyingTagFilters();
-                                      if (reason === 'clear'){
-                                        document.getElementById(TAG_FILTERS_INPUT_ID).value = '';
-                                        this.handleApplyTagFilters();
-                                      }
-                                    }}
-                                    onBlur={event => {
-                                      if (this.handleApplyTagFilters()) { this.setState({ modifyingTagFilters: false }); }
-                                      else {
-                                        const input = event.target;
-                                        defer(() => { input.focus(); });
-                                      }
-                                    }}
-                                    onKeyDown={event => { if (event.key === 'Escape') { this.handleCancelModifyingTagFilters(); } }}
-                                    onKeyPress={event => { if (event.key === 'Enter') { event.target.blur(); } }}
-                                  />
-                                  </Grid>
-                                  <Grid item xs={1}>
-                                <div style={{float: "right"}}>
-                                  { (this.state.modifyingTagFilters) ? null : 
-                                      (this.state.currentTagFiltersStr === '') ? null :
-                                        (currentTagFiltersSaved) ?
-                                        <IconButton title="Unpersist Filter" style={{padding: "0px", paddingRight: "10px", paddingTop: "5px"}}>
-                                            <RemoveCircleIcon 
-                                            color="primary"
-                                            onClick={() => {
-                                              document.getElementById(TAG_FILTERS_INPUT_ID).value = "";
-                                              this.handleUnpersistCurrentTagFilters();
-                                              this.handleApplyTagFilters();
-                                            }}
-                                            />
-                                        </IconButton> :
-                                        <IconButton title="Persist Filter" style={{padding: "0px", paddingRight: "10px", paddingTop: "5px"}}>
-                                            <SaveIcon 
-                                            color="primary"
-                                            onClick={() => {
-                                              this.handlePersistNewSavedTagFilters();
-                                            }}
-                                            />
-                                        </IconButton>                                     
-                                    
-                                  }
-                                </div>      
-                                </Grid>                  
-                                </Grid>
-
-                            </div>
-                            : null
-                        }
-                    </div>
-                    <IconButton
-                    edge="end"
-                    aria-label="account of current user"
-                    aria-haspopup="true"
-                    color="inherit"
-                    style={{float: "right"}}
-                    >
-                    <AccountCircleIcon color="secondary"/>
-                    </IconButton>
-                </Toolbar>
-            </AppBar>
-            )
-    }
+	state = DEFAULT_STATE;
+	
+	handleSave = () => {
+		if (checkSourceFileId(this.props.currentOpenFileId)) {
+			FileStorageSystemClient.doSaveSourceContent(
+				BlockTaggingEditorExtension.editor.value(true),
+				this.props.currentOpenFileId.sourceId,
+			).then(success => {
+				if (success) {
+					this.props.dispatchSetToastAction({
+						message: "Saved source file",
+						severity: TOAST_SEVERITY.SUCCESS,
+						open: true
+					});
+					store.dispatch({ type: CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE });
+				}
+				else {
+					this.props.dispatchSetToastAction({
+						message: "Failed to save source file",
+						severity: TOAST_SEVERITY.ERROR,
+						open: true
+					});
+				}
+			});
+		} else if (checkViewFileId(this.props.currentOpenFileId) && this.props.currentOpenFileId.viewType !== NO_OPEN_FILE_ID.viewType) {
+			FileStorageSystemClient.doSaveViewSpec(
+				this.props.tagsInView,
+				this.props.currentOpenFileId.sourceId,
+				this.props.currentOpenFileId.viewId,
+				this.props.currentOpenFileId.viewType,
+				false,
+				)
+				.then(() => {
+					this.props.dispatchSetToastAction({
+						message: "View saved",
+						severity: TOAST_SEVERITY.SUCCESS,
+						open: true
+					});
+					store.dispatch({ type: CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE });
+				})
+				.catch(() => this.props.dispatchSetToastAction({
+					message: "Failed to save view",
+					severity: TOAST_SEVERITY.ERROR,
+					open: true
+				}));
+		}
+	}
+	
+	handleCancelModifyingTagFilters = () => {
+		const input = document.getElementById(TAG_FILTERS_INPUT_ID);
+		input.value = this.state.currentTagFiltersStr;
+		this.setState({ modifyingTagFilters: false });
+	};
+	
+	handleStartModifyingTagFilters = () => {
+		this.setState({ modifyingTagFilters: true });
+		defer(() => {
+			const input = document.getElementById(TAG_FILTERS_INPUT_ID);
+			input.focus();
+			input.setSelectionRange(input.value.length, input.value.length);
+		});
+	};
+	
+	handleUnpersistCurrentTagFilters = () => {
+		if (
+			!this.state.currentTagFiltersStr ||
+			!this.state.sourceSavedTagFilters.hasOwnProperty(this.state.currentTagFiltersStr)
+		) { return false; }
+		const newSourceSavedTagFilters = {...this.state.sourceSavedTagFilters};
+		delete newSourceSavedTagFilters[this.state.currentTagFiltersStr];
+		FileStorageSystemClient.doSetSourceSavedTagFilters(
+			this.props.currentOpenFileId.sourceId,
+			newSourceSavedTagFilters,
+		).then(success => {
+			if (!success) {
+				this.props.dispatchSetToastAction({
+					message: "Failed to set source saved tag filters",
+					severity: TOAST_SEVERITY.ERROR,
+					open: true
+				});
+			}
+			else { this.setState({ sourceSavedTagFilters: newSourceSavedTagFilters }); }
+		});
+	};
+	
+	handlePersistNewSavedTagFilters = () => {
+		if (
+			!this.state.currentTagFiltersStr ||
+			this.state.sourceSavedTagFilters.hasOwnProperty(this.state.currentTagFiltersStr)
+		) { return false; }
+		const newSourceSavedTagFilters = {...this.state.sourceSavedTagFilters};
+		newSourceSavedTagFilters[this.state.currentTagFiltersStr] = this.state.currentParsedTagFiltersStr;
+		FileStorageSystemClient.doSetSourceSavedTagFilters(
+			this.props.currentOpenFileId.sourceId,
+			newSourceSavedTagFilters,
+		).then(success => {
+			if (!success) {
+				this.props.dispatchSetToastAction({
+					message: "Failed to set source saved tag filters",
+					severity: TOAST_SEVERITY.ERROR,
+					open: true
+				});
+			}
+			else { this.setState({ sourceSavedTagFilters: newSourceSavedTagFilters }); }
+		});
+	};
+	
+	handleApplyTagFilters = () => {
+		let tagFilters = null;
+		const tagFiltersStr = document.getElementById(TAG_FILTERS_INPUT_ID).value.trim();
+		if (tagFiltersStr) {
+			tagFilters = parseTagFilters(tagFiltersStr);
+			if (!tagFilters) {
+				this.props.dispatchSetToastAction({
+					message: "Invalid tag filters",
+					severity: TOAST_SEVERITY.ERROR,
+					open: true
+				});
+				return false;
+			}
+		}
+		document.getElementById(TAG_FILTERS_INPUT_ID).value = tagFiltersStr;
+		const parsedTagFiltersStr = JSON.stringify(tagFilters);
+		const oldParsedTagFiltersStr = this.state.currentParsedTagFiltersStr;
+		this.setState({ currentTagFiltersStr: tagFiltersStr, currentParsedTagFiltersStr: parsedTagFiltersStr });
+		if (parsedTagFiltersStr === oldParsedTagFiltersStr) { return true; }
+		if(BlockTaggingEditorExtension.editor !== undefined){
+			BlockTaggingEditorExtension.editor.view.dispatch(
+				BlockTaggingEditorExtension.editor.view.state.tr.setMeta(TagFilteringPluginKey, tagFilters)
+					.setSelection(
+						tagFilters
+							? TextSelection.create(BlockTaggingEditorExtension.editor.view.state.doc, 0, 0)
+							: Selection.atStart(BlockTaggingEditorExtension.editor.view.state.doc)
+					).scrollIntoView()
+			);
+			defer(() => {
+				if (tagFilters) { BlockTaggingEditorExtension.editor.view.dom.blur(); }
+				else { BlockTaggingEditorExtension.editor.view.focus(); }
+			});
+		}
+		return true;
+	};
+	
+	changeFile = async () => {
+		if (checkSourceFileId(this.props.currentOpenFileId)) {
+			FileStorageSystemClient.doGetSourceSavedTagFilters(this.props.currentOpenFileId.sourceId)
+				.then(sourceSavedTagFilters => {
+					if (!sourceSavedTagFilters) {
+						this.props.dispatchSetToastAction({
+							message: "Failed to retrieve source saved tag filters",
+							severity: TOAST_SEVERITY.ERROR,
+							open: true
+						});
+					} else {
+						let filters = {}
+						sourceSavedTagFilters.forEach(element => {
+							filters[element] = element;
+						});
+						this.setState({sourceSavedTagFilters: filters});
+					}
+				});
+		}
+	};
+	
+	componentDidMount = () => {
+		this.changeFile();
+	};
+	
+	componentDidUpdate = prevProps => {
+		if(this.props.currentOpenFileName.viewName === '' && prevProps.currentOpenFileId.sourceId !== this.props.currentOpenFileId.sourceId){
+			document.getElementById(TAG_FILTERS_INPUT_ID).value = "";
+			this.handleApplyTagFilters();
+			this.setState({ sourceSavedTagFilters: {} });
+			this.changeFile();
+		}
+	};
+	
+	render = () => {
+		const noOpenFileIdCheck = checkNoOpenFileId(this.props.currentOpenFileId);
+		const currentTagFiltersSaved =this.state.sourceSavedTagFilters.hasOwnProperty(this.state.currentTagFiltersStr);
+		return(
+			<AppBar position="static" class="custom-navbar">
+				<Toolbar>
+					<img className={"menuButton"} src={require('../images/logo.png')} style={{width: "40px", marginRight: "10px"}} alt={"MENU"}/>
+					<Typography variant="h5" style={{fontFamily:"Bungee", color:"#F5F0E1"}}>
+						YADA
+					</Typography>
+					<div style={{flexGrow: 1, marginLeft: "150px"}}>
+						{this.props.currentOpenFileName.sourceName === '' ? null :
+							<Breadcrumbs aria-label="breadcrumb" color="secondary" style={{marginRight: "10px", float: "left", border:"1px solid #F5F0E1", borderRadius: "10px", padding: "8px"}}>
+								<Link color="inherit" style={{ color: "#F5F0E1",}}>
+									<DescriptionIcon color="secondary"/>
+									{this.props.currentOpenFileName.sourceName}
+								</Link>
+								{this.props.currentOpenFileName.viewName === '' ? null :
+									<Link color="inherit" style={{color: "#F5F0E1"}}>
+										{
+											(this.props.currentOpenFileId.viewType === FILE_TYPE.CARD_VIEW) ?
+												<AmpStoriesIcon color="secondary"/>:
+												(this.props.currentOpenFileId.viewType === FILE_TYPE.TEXT_VIEW) ?
+													<TextFieldsIcon color="secondary"/> :
+													null
+										}
+										{this.props.currentOpenFileName.viewName}
+									</Link>
+								}
+							</Breadcrumbs>
+						}
+						<Button
+							variant="outlined"
+							color="secondary"
+							title="save"
+							disabled={noOpenFileIdCheck || !this.props.saveDirtyFlag}
+							onClick={this.handleSave}
+							startIcon={<SaveIcon />}
+							style= {{ borderRadius: "10px",paddingTop: "8px", paddingBottom: "8px", float: "left", marginRight: "20px" }}
+						>
+							Save
+						</Button>
+						{
+							this.props.currentOpenFileName.viewName === '' ?
+								<div style={{backgroundColor: "rgba(245, 240, 225, 0.8)", marginLeft: "250px", width: "50vw", borderRadius: "10px", padding: "5px"}}>
+									<Grid container>
+										<Grid item xs={1}>
+											<div style={{marginTop: "3px", marginLeft: "20px"}}>
+												<SearchIcon color="primary"/>
+											</div>
+										</Grid>
+										<Grid item xs={10}>
+											<Autocomplete
+												value={this.state.currentTagFiltersStr}
+												id={TAG_FILTERS_INPUT_ID}
+												freeSolo
+												options={Object.entries(this.state.sourceSavedTagFilters)
+													.map(([tagFiltersStr, _parsedTagFiltersStr]) => tagFiltersStr)}
+												renderInput={(params) => (
+													<TextField
+														{...params}
+														placeholder="Search with Tags: ( #{tag1} | !( #{tag2} ) ) & #{tag3}"
+														style={{margin:"0%"}}
+														margin="normal"
+														variant="standard"
+													/>
+												)}
+												onChange={(event, value, reason) => {
+													this.setState({currentTagFiltersStr : value});
+													this.handleStartModifyingTagFilters();
+													if (reason === 'clear'){
+														document.getElementById(TAG_FILTERS_INPUT_ID).value = '';
+														this.handleApplyTagFilters();
+													}
+												}}
+												onBlur={event => {
+													if (this.handleApplyTagFilters()) { this.setState({ modifyingTagFilters: false }); }
+													else {
+														const input = event.target;
+														defer(() => { input.focus(); });
+													}
+												}}
+												onKeyDown={event => { if (event.key === 'Escape') { this.handleCancelModifyingTagFilters(); } }}
+												onKeyPress={event => { if (event.key === 'Enter') { event.target.blur(); } }}
+											/>
+										</Grid>
+										<Grid item xs={1}>
+											<div style={{float: "right"}}>
+												{ (this.state.modifyingTagFilters) ? null :
+													(this.state.currentTagFiltersStr === '') ? null :
+														(currentTagFiltersSaved) ?
+															<IconButton title="Unpersist Filter" style={{padding: "0px", paddingRight: "10px", paddingTop: "5px"}}>
+																<RemoveCircleIcon
+																	color="primary"
+																	onClick={() => {
+																		document.getElementById(TAG_FILTERS_INPUT_ID).value = "";
+																		this.handleUnpersistCurrentTagFilters();
+																		this.handleApplyTagFilters();
+																	}}
+																/>
+															</IconButton> :
+															<IconButton title="Persist Filter" style={{padding: "0px", paddingRight: "10px", paddingTop: "5px"}}>
+																<SaveIcon
+																	color="primary"
+																	onClick={() => {
+																		this.handlePersistNewSavedTagFilters();
+																	}}
+																/>
+															</IconButton>
+													
+												}
+											</div>
+										</Grid>
+									</Grid>
+								
+								</div>
+								: null
+						}
+					</div>
+					<IconButton
+						edge="end"
+						aria-label="account of current user"
+						aria-haspopup="true"
+						color="inherit"
+						style={{float: "right"}}
+					>
+						<AccountCircleIcon color="secondary"/>
+					</IconButton>
+				</Toolbar>
+			</AppBar>
+		)
+	}
 }
 
 export default connect(
-    state => ({ currentOpenFileId: state.currentOpenFileId, currentOpenFileName: state.currentOpenFileName, backendModeSignedInStatus: state.backendModeSignedInStatus, saveDirtyFlag: state.saveDirtyFlag }),
-    dispatch => ({
-      dispatchSetBackendModeSignedInStatusAction: mode => dispatch(setBackendModeSignedInStatusAction(mode)),
-    }),
-  )(Navbar);
+	state => ({
+		currentOpenFileId: state.currentOpenFileId,
+		currentOpenFileName: state.currentOpenFileName,
+		backendModeSignedInStatus: state.backendModeSignedInStatus,
+		tagsInView: state.tagsInView,
+		saveDirtyFlag: state.saveDirtyFlag
+	}),
+	dispatch => ({
+		dispatchSetBackendModeSignedInStatusAction: mode => dispatch(setBackendModeSignedInStatusAction(mode)),
+		dispatchSetToastAction: toast => dispatch(setToastAction(toast)),
+	}),
+)(Navbar);

--- a/src/components/TagMenu.js
+++ b/src/components/TagMenu.js
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 import {SET_SAVE_DIRTY_FLAG_ACTION_TYPE} from '../reducers/CurrentOpenFileState';
 
 import BlockTaggingEditorExtension from '../editor_extension/BlockTagging';
+import {setToastAction, TOAST_SEVERITY} from "../reducers/Toast";
 
 const BLOCK_NODE_TAGS_LIST_ID = 'block_node_tags_list';
 
@@ -24,7 +25,11 @@ class TagMenu extends React.Component {
     const tag = document.getElementById(ADD_TAG_INPUT_ID).value.trim();
     if (!tag || INVALID_TAG_VALUE_REGEX.test(tag) || !this.props.selectNode) { return false; }
     if (this.state.selectNodeAttrs.hasOwnProperty('tags') && this.state.selectNodeAttrs.tags.hasOwnProperty(tag)) {
-      alert('tag value "' + tag + '" already exists');
+      this.props.dispatchSetToastAction({
+        message: `Tag value "${tag}" already exists`,
+        severity: TOAST_SEVERITY.ERROR,
+        open: true
+      });
       return false;
     }
     const newSelectNodeAttrs = { ...this.state.selectNodeAttrs, tags: {...this.state.selectNodeAttrs.tags} };
@@ -69,7 +74,11 @@ class TagMenu extends React.Component {
     ) { return false; }
     if (newTagValue === oldTagValue) { return true; }
     if (this.state.selectNodeAttrs.tags.hasOwnProperty(newTagValue)) {
-      alert('tag value "' + newTagValue + '" already exists');
+      this.props.dispatchSetToastAction({
+        message: `Tag value ${newTagValue} already exists`,
+        severity: TOAST_SEVERITY.ERROR,
+        open: true
+      });
       return false;
     }
     const newSelectNodeAttrs = { ...this.state.selectNodeAttrs, tags: {...this.state.selectNodeAttrs.tags} };
@@ -211,5 +220,8 @@ export default connect(
     saveDirtyFlag: state.saveDirtyFlag,
     currentOpenFileId: state.currentOpenFileId,
   }),
-  dispatch => ({ dispatchSetSaveDirtyFlagAction: () => dispatch({ type: SET_SAVE_DIRTY_FLAG_ACTION_TYPE }) }),
+  dispatch => ({
+    dispatchSetSaveDirtyFlagAction: () => dispatch({ type: SET_SAVE_DIRTY_FLAG_ACTION_TYPE }),
+    dispatchSetToastAction: toast => dispatch(setToastAction(toast)),
+  }),
 )(TagMenu);

--- a/src/components/TextView/TextView.js
+++ b/src/components/TextView/TextView.js
@@ -8,6 +8,9 @@ import {setTagsInViewAction} from '../../reducers/SetTagsInView';
 import FileStorageSystemClient from "../../backend/FileStorageSystemClient";
 import {FILE_TYPE} from "../../util/FileIdAndTypeUtils";
 import RichMarkdownEditor from "rich-markdown-editor";
+import {setToastAction, TOAST_SEVERITY} from "../../reducers/Toast";
+import store from "../../store";
+import {CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE} from "../../reducers/CurrentOpenFileState";
 
 
 class TextView extends React.Component {
@@ -30,8 +33,19 @@ class TextView extends React.Component {
 				FILE_TYPE.TEXT_VIEW,
 				false,
 				)
-				.then(() => alert("Text view saved"))
-				.catch(() => alert("Failed to save text view"));
+				.then(() => {
+					this.props.dispatchSetToastAction({
+						message: "Saved view",
+						severity: TOAST_SEVERITY.SUCCESS,
+						open: true
+					});
+					store.dispatch({ type: CLEAR_SAVE_DIRTY_FLAG_ACTION_TYPE });
+				})
+				.catch(() => this.props.dispatchSetToastAction({
+					message: "Failed to save view",
+					severity: TOAST_SEVERITY.ERROR,
+					open: true
+				}));
 		}
 	};
 	
@@ -62,7 +76,7 @@ class TextView extends React.Component {
 		} else {
 			return (
 				<Container className="viewContainer">
-					<TagEditor allTagsData={this.state.allTagsData} tagsInView={this.props.tagsInView} />
+					<TagEditor viewType={FILE_TYPE.TEXT_VIEW} allTagsData={this.state.allTagsData} tagsInView={this.props.tagsInView} />
 					{
 						this.props.tagsInView.length > 0 &&
 						<RichMarkdownEditor
@@ -81,5 +95,8 @@ class TextView extends React.Component {
 
 export default connect(
 	state => ({ tagsInView: state.tagsInView, currentOpenFileId: state.currentOpenFileId }),
-	dispatch => ({ setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)) }),
+	dispatch => ({
+		setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)),
+		dispatchSetToastAction: toast => dispatch(setToastAction(toast)),
+	}),
 )(TextView);

--- a/src/components/ViewComponents/DragDropColumn.js
+++ b/src/components/ViewComponents/DragDropColumn.js
@@ -1,6 +1,9 @@
 import styled from 'styled-components'
 import React from 'react';
 import {Droppable, Draggable} from 'react-beautiful-dnd';
+import {THEME} from "../../App";
+import {FILE_TYPE} from "../../util/FileIdAndTypeUtils";
+import {TAG_HOLDERS} from "./TagEditor";
 
 class Tag extends React.Component {
 	render = () => {
@@ -9,7 +12,7 @@ class Tag extends React.Component {
 			border-radius: 10px;
 			padding: 8px;
 			margin-bottom: 8px;
-			background-color: ${props => (props.isDragging ? 'lightgreen' : 'white')};
+			background-color: ${props => (props.isDragging ? THEME.palette.secondary.dark : THEME.palette.secondary.light)};
 		`;
 		const TagId = styled.h5``;
 		const Content = styled.div``
@@ -38,9 +41,21 @@ class InnerTagList extends React.Component {
 	}
 	
 	render() {
-		return Object.keys(this.props.tagData).map((tagId, index) => (
-			<Tag key={tagId} tagId={tagId} index={index} tagInfo={this.props.tagData[tagId]}/>
-		));
+		console.log(this.props);
+		const tagList = [];
+		const tagIds = Object.keys(this.props.tagData);
+		for (let i = 0; i < tagIds.length; ++i) {
+			const tagId = tagIds[i];
+			tagList.push(<Tag key={tagId} tagId={tagId} index={i} tagInfo={this.props.tagData[tagId]}/>);
+			if (this.props.viewType === FILE_TYPE.CARD_VIEW && this.props.columnId === TAG_HOLDERS.IN_VIEW) {
+				if (i % 2 === 1 && i !== tagIds.length-1) {
+					tagList.push(
+						<hr style={{ color: THEME.palette.primary.main, backgroundColor: THEME.palette.primary.main, height: 1 }} />
+					);
+				}
+			}
+		}
+		return tagList;
 	}
 }
 
@@ -71,7 +86,7 @@ class DragDropColumn extends React.Component {
 			margin-top: 10px;
 			margin-bottom: 10px;
 			transition: background-color 0.2s ease;
-			background-color: ${props => (props.isDraggingOver) ? 'skyblue' : 'white'};
+			background-color: ${props => (props.isDraggingOver) ? THEME.palette.grey[300] : THEME.palette.grey[100]};
 		`;
 		const Title = styled.h3`
 			padding: 8px;
@@ -97,7 +112,7 @@ class DragDropColumn extends React.Component {
 									{...provided.droppableProps}
 								>
 									<TagList ref={this.tagListRef}>
-										<InnerTagList tagData={this.props.tagData}/>
+										<InnerTagList viewType={this.props.viewType} columnId={this.props.column.id} tagData={this.props.tagData}/>
 										{provided.placeholder}
 									</TagList>
 								</DroppableRegion>

--- a/src/components/ViewComponents/TagEditor.js
+++ b/src/components/ViewComponents/TagEditor.js
@@ -6,6 +6,12 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import {DragDropContext} from 'react-beautiful-dnd';
 import {setTagsInViewAction} from '../../reducers/SetTagsInView';
+import {SET_SAVE_DIRTY_FLAG_ACTION_TYPE} from "../../reducers/CurrentOpenFileState";
+
+export const TAG_HOLDERS = {
+	AVAILABLE: "tags_available",
+	IN_VIEW: "tags_in_view"
+}
 
 class TagEditor extends React.Component {
 	constructor(props) {
@@ -41,12 +47,12 @@ class TagEditor extends React.Component {
 			tagData: tagData,
 			columns: {
 				tags_in_view: {
-					id: 'tags_in_view',
+					id: TAG_HOLDERS.IN_VIEW,
 					title: "Tags in View",
 					tagIds: this.props.tagsInView
 				},
 				tags_available: {
-					id: 'tags_available',
+					id: TAG_HOLDERS.AVAILABLE,
 					title: "Available Tags",
 					tagIds: availableTags
 				},
@@ -111,6 +117,7 @@ class TagEditor extends React.Component {
 	
 	componentDidUpdate(prevProps, prevState, snapshot) {
 		if (prevProps.tagsInView !== this.props.tagsInView) {
+			if (!this.props.saveDirtyFlag) { this.props.dispatchSetSaveDirtyFlagAction(); }
 			const tagsInView = new Set(this.props.tagsInView);
 			const availableTags = Object.keys(this.props.allTagsData).filter(t => !tagsInView.has(t));
 			const newState = Object.assign({}, this.state);
@@ -134,7 +141,12 @@ class TagEditor extends React.Component {
 							}
 							return (
 								<Col key={column.id} md="12" lg="6">
-									<DragDropColumn key={column.id} column={column} tagData={tagDataInColumn}/>
+									<DragDropColumn
+										viewType={this.props.viewType}
+										key={column.id}
+										column={column}
+										tagData={tagDataInColumn}
+									/>
 								</Col>
 							);
 						})}
@@ -146,6 +158,9 @@ class TagEditor extends React.Component {
 }
 
 export default connect(
-	state => ({ tagsInView: state.tagsInView }),
-	dispatch => ({ setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)) }),
+	state => ({ tagsInView: state.tagsInView, saveDirtyFlag: state.saveDirtyFlag }),
+	dispatch => ({
+		setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)),
+		dispatchSetSaveDirtyFlagAction: () => dispatch({ type: SET_SAVE_DIRTY_FLAG_ACTION_TYPE })
+	}),
 )(TagEditor);

--- a/src/components/ViewEditor.js
+++ b/src/components/ViewEditor.js
@@ -10,6 +10,7 @@ import {handleSetCurrentOpenFileId} from "./Navigator";
 import CardDeck from "./CardView/CardDeck";
 import TextView from "./TextView/TextView";
 import {setTagsInViewAction} from "../reducers/SetTagsInView";
+import {setToastAction, TOAST_SEVERITY} from "../reducers/Toast";
 
 const DEFAULT_STATE = {
 	sourceId: 0,
@@ -25,7 +26,11 @@ class ViewEditor extends React.Component {
 	changeFile = async () => {
 		FileStorageSystemClient.doGetView(this.props.currentOpenFileId).then(value => {
 			if (value === null) {
-				alert('failed to retrieve view');
+				this.props.dispatchSetToastAction({
+					message: "Failed to retrieve view",
+					severity: TOAST_SEVERITY.ERROR,
+					open: true
+				})
 				handleSetCurrentOpenFileId(NO_OPEN_FILE_ID);
 			} else {
 				this.props.setTagsInView([]); // clear any tagsInView currently stored
@@ -66,6 +71,9 @@ class ViewEditor extends React.Component {
 
 export default connect(
 	state => ({ currentOpenFileId: state.currentOpenFileId }),
-	dispatch => ({ setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)) }),
+	dispatch => ({
+		setTagsInView: tagsInView => dispatch(setTagsInViewAction(tagsInView)),
+		dispatchSetToastAction: toast => dispatch(setToastAction(toast)),
+	}),
 )(ViewEditor);
 

--- a/src/reducers/CurrentOpenFileState.js
+++ b/src/reducers/CurrentOpenFileState.js
@@ -20,7 +20,7 @@ const initialFileId = {
   sourceId: storedInitialFileId.hasOwnProperty('sourceId')
     ? storedInitialFileId.sourceId : NO_OPEN_FILE_ID.sourceId,
   viewId: storedInitialFileId.hasOwnProperty('viewId') ? storedInitialFileId.viewId : NO_OPEN_FILE_ID.viewId,
-  viewType: storedInitialFileId.hasOwnProperty('viewType') ? storedInitialFileId.viewType : NO_OPEN_FILE_ID.viewId,
+  viewType: storedInitialFileId.hasOwnProperty('viewType') ? storedInitialFileId.viewType : NO_OPEN_FILE_ID.viewType,
 }
 
 const initialFileName = {

--- a/src/reducers/Toast.js
+++ b/src/reducers/Toast.js
@@ -1,0 +1,20 @@
+export const SET_TOAST_ACTION_TYPE = 'toast/set';
+export const setToastAction = toast => ({ type: SET_TOAST_ACTION_TYPE, toast });
+
+export const TOAST_DURATION_MS = 5000;
+export const TOAST_CLEAR = 'clear';
+export const TOAST_SEVERITY = {
+	ERROR: 'error',
+	WARNING: 'warning',
+	INFO: 'info',
+	SUCCESS: 'success',
+}
+const DEFAULT_STATE = {
+	message: "",
+	severity: TOAST_SEVERITY.INFO,
+	open: false
+}
+
+export const setToastReducer = (state = DEFAULT_STATE, action) =>
+	action.type !== SET_TOAST_ACTION_TYPE || !action.hasOwnProperty('toast')
+		? state : (action === TOAST_CLEAR ? DEFAULT_STATE : action.toast);

--- a/src/store.js
+++ b/src/store.js
@@ -3,6 +3,7 @@ import {combineReducers} from 'redux';
 import {currentOpenFileIdReducer, saveDirtyFlagReducer, selectNodeReducer, currentOpenFileNameReducer} from './reducers/CurrentOpenFileState';
 import {backendModeSignedInStatusReducer} from './reducers/BackendModeSignedInStatus';
 import {setTagsInViewReducer} from "./reducers/SetTagsInView";
+import {setToastReducer} from "./reducers/Toast";
 
 export default configureStore({
   reducer: combineReducers({
@@ -11,6 +12,7 @@ export default configureStore({
     saveDirtyFlag: saveDirtyFlagReducer,
     selectNode: selectNodeReducer,
     backendModeSignedInStatus: backendModeSignedInStatusReducer,
-    tagsInView: setTagsInViewReducer
+    tagsInView: setTagsInViewReducer,
+    toast: setToastReducer,
   }),
 });


### PR DESCRIPTION
- Replaced `alert` with toast messages that autoclose in 5 seconds
- Added ability to save card and text views
- Themified Tag Editor and added line breaks for Tags In VIew for Cards to help user understand which blocks belong to the same card

<img width="1525" alt="Screen Shot 2021-02-04 at 6 20 01 PM" src="https://user-images.githubusercontent.com/9358846/106968076-2f927180-6716-11eb-99d0-a80d6a3da1fc.png">
<img width="1527" alt="Screen Shot 2021-02-04 at 6 18 02 PM" src="https://user-images.githubusercontent.com/9358846/106968078-30c39e80-6716-11eb-80b8-65f1b61bb7b7.png">
