### PR TITLE
Fixed Tour to open after file load

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -171,9 +171,7 @@ class App extends React.Component {
                 }}
               />
               <Steps
-                enabled={
-                  this.state.documentStepsStart && this.props.tagMenuOpened
-                }
+                enabled={this.state.documentStepsStart && this.props.fileOpened}
                 steps={this.state.documentTourSteps}
                 initialStep={0}
                 onExit={this.onDocumentStepsExit}
@@ -214,7 +212,7 @@ export default connect(
     currentOpenFileId: state.currentOpenFileId,
     currentOpenFileName: state.currentOpenFileName,
     toast: state.toast,
-    tagMenuOpened: state.tagMenuOpened,
+    fileOpened: state.fileOpened,
     stepsNavigator: state.stepsNavigator,
     newUser: state.newUser,
   }),

--- a/src/components/SourceEditorWithTagFiltersInput.js
+++ b/src/components/SourceEditorWithTagFiltersInput.js
@@ -24,6 +24,7 @@ import {
   SET_SAVE_IN_PROGRESS,
   CLEAR_SAVE_IN_PROGRESS,
 } from "../reducers/CurrentOpenFileState";
+import { setFileOpenedAction } from "../reducers/Steps";
 
 export const INITIAL_TAG_FILTERS_LOCAL_STORAGE_KEY = "initialTagFilters";
 
@@ -99,6 +100,7 @@ class SourceEditorWithTagFiltersInput extends React.Component {
           });
           handleSetCurrentOpenFileId(NO_OPEN_FILE_ID);
         } else {
+          this.props.dispatchSetFileOpenedAction(true);
           this.setState({ fileIdKeyStr, fileContent: value ?? "" });
         }
       });
@@ -122,6 +124,7 @@ class SourceEditorWithTagFiltersInput extends React.Component {
         this.props.currentOpenFileId.sourceId ||
       prevProps.currentOpenFileId.viewId !== this.props.currentOpenFileId.viewId
     ) {
+      this.props.dispatchSetFileLoading();
       this.changeFile();
     }
   };
@@ -158,5 +161,7 @@ export default connect(
     dispatchSetToastAction: (toast) => dispatch(setToastAction(toast)),
     dispatchSetFileLoading: () => dispatch({ type: SET_FILE_LOADING }),
     dispatchClearFileLoading: () => dispatch({ type: CLEAR_FILE_LOADING }),
+    dispatchSetFileOpenedAction: (fileOpened) =>
+      dispatch(setFileOpenedAction(fileOpened)),
   })
 )(SourceEditorWithTagFiltersInput);

--- a/src/components/SourceEditorWithTagFiltersInput.js
+++ b/src/components/SourceEditorWithTagFiltersInput.js
@@ -124,7 +124,6 @@ class SourceEditorWithTagFiltersInput extends React.Component {
         this.props.currentOpenFileId.sourceId ||
       prevProps.currentOpenFileId.viewId !== this.props.currentOpenFileId.viewId
     ) {
-      this.props.dispatchSetFileLoading();
       this.changeFile();
     }
   };

--- a/src/components/TagMenu.js
+++ b/src/components/TagMenu.js
@@ -7,7 +7,6 @@ import { SET_SAVE_DIRTY_FLAG_ACTION_TYPE } from "../reducers/CurrentOpenFileStat
 
 import BlockTaggingEditorExtension from "../editor_extension/BlockTagging";
 import { setToastAction, TOAST_SEVERITY } from "../reducers/Toast";
-import { setTagMenuOpenedAction } from "../reducers/Steps";
 import OutlinedInput from "@material-ui/core/OutlinedInput";
 import AddCircleIcon from "@material-ui/icons/AddCircle";
 import InputAdornment from "@material-ui/core/InputAdornment";
@@ -161,9 +160,6 @@ class TagMenu extends React.Component {
     return true;
   };
 
-  componentDidMount = () => {
-    this.props.dispatchSetTagMenuOpenedAction(true);
-  };
   componentDidUpdate = (prevProps) => {
     if (
       prevProps.currentOpenFileId.sourceId !==
@@ -384,7 +380,5 @@ export default connect(
     dispatchSetSaveDirtyFlagAction: () =>
       dispatch({ type: SET_SAVE_DIRTY_FLAG_ACTION_TYPE }),
     dispatchSetToastAction: (toast) => dispatch(setToastAction(toast)),
-    dispatchSetTagMenuOpenedAction: (tagMenuOpened) =>
-      dispatch(setTagMenuOpenedAction(tagMenuOpened)),
   })
 )(TagMenu);

--- a/src/reducers/Steps.js
+++ b/src/reducers/Steps.js
@@ -1,12 +1,10 @@
-export const SET_TAG_MENU_OPENED_ACTION_TYPE = "tagMenuOpened/set";
-export const setTagMenuOpenedAction = (tagMenuOpened) => ({
-  type: SET_TAG_MENU_OPENED_ACTION_TYPE,
-  tagMenuOpened,
+export const SET_FILE_OPENED_ACTION_TYPE = "fileOpened/set";
+export const setFileOpenedAction = (fileOpened) => ({
+  type: SET_FILE_OPENED_ACTION_TYPE,
+  fileOpened,
 });
-export const setTagMenuOpenedReducer = (state = false, action) =>
-  action.type !== SET_TAG_MENU_OPENED_ACTION_TYPE
-    ? state
-    : action.tagMenuOpened;
+export const setFileOpenedReducer = (state = false, action) =>
+  action.type !== SET_FILE_OPENED_ACTION_TYPE ? state : action.fileOpened;
 
 export const SET_TAG_EDITOR_OPENED_ACTION_TYPE = "tagEditorOpened/set";
 export const setTagEditorOpenedAction = (tagEditorOpened) => ({

--- a/src/store.js
+++ b/src/store.js
@@ -13,9 +13,9 @@ import { backendModeSignedInStatusReducer } from "./reducers/BackendModeSignedIn
 import { setTagsInViewReducer } from "./reducers/SetTagsInView";
 import { setToastReducer } from "./reducers/Toast";
 import {
-  setTagMenuOpenedReducer,
   setNewUserReducer,
   setTagEditorOpenedReducer,
+  setFileOpenedReducer,
 } from "./reducers/Steps";
 
 const reducers = combineReducers({
@@ -28,7 +28,7 @@ const reducers = combineReducers({
   backendModeSignedInStatus: backendModeSignedInStatusReducer,
   tagsInView: setTagsInViewReducer,
   toast: setToastReducer,
-  tagMenuOpened: setTagMenuOpenedReducer,
+  fileOpened: setFileOpenedReducer,
   newUser: setNewUserReducer,
   tagEditorOpened: setTagEditorOpenedReducer,
 });


### PR DESCRIPTION
Before we were checking for tagMenuOpened to start the tour. However with the progress stuff, we first rendered the tag menu and then immediately when to the progress bar. This caused problems because it kick started the tour without the file so tag menu wasnt getting highlighted. Changed to start the tour after file is loaded. 